### PR TITLE
Add Intellisense support files generation for rush.yaml

### DIFF
--- a/lib/commands/create_command/create_command.dart
+++ b/lib/commands/create_command/create_command.dart
@@ -6,6 +6,7 @@ import 'package:hive/hive.dart';
 import 'package:path/path.dart' as p;
 import 'package:rush_cli/helpers/cmd_utils.dart';
 import 'package:rush_cli/templates/rules_pro.dart';
+import 'package:rush_cli/templates/vscode_files.dart';
 
 import 'package:rush_prompt/rush_prompt.dart';
 import 'package:rush_cli/templates/intellij_files.dart';
@@ -183,6 +184,18 @@ class CreateCommand extends Command {
           getModulesXml(kebabCasedName));
       CmdUtils.writeFile(
           p.join(projectDir, '.idea', '$kebabCasedName.iml'), getIml());
+
+      // Json Schema File (Adds supports for rush.yam file intellisense)
+      CmdUtils.writeFile(
+        p.join(projectDir, '.idea', 'jsonSchemas.xml'),
+        getJsonSchemaForIdea(),
+      );
+
+      // VS Code Path : .vscode/settings.json
+      CmdUtils.writeFile(
+        p.join(projectDir, '.vscode', 'settings.json'),
+        getJsonSchemaForVsCode(),
+      );
     } catch (e) {
       Logger.log(LogType.erro, e.toString());
       exit(1);

--- a/lib/templates/intellij_files.dart
+++ b/lib/templates/intellij_files.dart
@@ -76,3 +76,30 @@ String getModulesXml(String name) {
 </project>
 ''';
 }
+
+String getJsonSchemaForIdea() => '''
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="Rush YAML">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="Rush YAML" />
+              <option name="relativePathToSchema" value="https://raw.githubusercontent.com/shreyashsaitwal/rush-cli/main/schema/rush.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="rush.yml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>
+''';

--- a/lib/templates/vscode_files.dart
+++ b/lib/templates/vscode_files.dart
@@ -1,0 +1,7 @@
+String getJsonSchemaForVsCode() => '''
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/shreyashsaitwal/rush-cli/main/schema/rush.json": "rush.yml"
+  }
+}
+''';


### PR DESCRIPTION
Now the create command will be able to automatically generate files required to add support for intellisense for rush.yaml fille. 

Following files are generated:
`.idea/jsonSchemas.xml`
`.vscode/settings.json`