### PR TITLE
Add support to convert R.txt to R.java from the aar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .packages
 .idea
 pubspec.lock
+*.iml
 
 # Conventional directory for build outputs
 build/
@@ -13,5 +14,4 @@ doc/api/
 misc/
 temp/
 
-*.iml
-env.dart
+/.vscode

--- a/lib/commands/create_command/create_command.dart
+++ b/lib/commands/create_command/create_command.dart
@@ -183,6 +183,13 @@ class CreateCommand extends Command {
           getModulesXml(kebabCasedName));
       CmdUtils.writeFile(
           p.join(projectDir, '.idea', '$kebabCasedName.iml'), getIml());
+
+      // Json Schema File (Adds supports for rush.yam file intellisense)
+      CmdUtils.writeFile(
+        p.join(projectDir, '.idea', 'jsonSchemas.xml'),
+        getJsonSchemaForIdea(),
+      );
+
     } catch (e) {
       Logger.log(LogType.erro, e.toString());
       exit(1);

--- a/lib/commands/create_command/create_command.dart
+++ b/lib/commands/create_command/create_command.dart
@@ -112,13 +112,14 @@ class CreateCommand extends Command {
       versionName = argResults!['version'].toString().trim();
     }
 
-    if ((argResults!['lang'] as List).isEmpty) {
+    final argLang = argResults!['lang'] as List;
+    if (argLang.isEmpty) {
       lang = MultipleChoiceQuestion(
         question: 'Language',
         options: ['Java', 'Kotlin'],
       ).ask();
     } else {
-      lang = argResults!['lang'].toString().trim();
+      lang = argLang.first.toString().trim();
     }
 
     final camelCasedName = Casing.camelCase(name);
@@ -189,7 +190,6 @@ class CreateCommand extends Command {
         p.join(projectDir, '.idea', 'jsonSchemas.xml'),
         getJsonSchemaForIdea(),
       );
-
     } catch (e) {
       Logger.log(LogType.erro, e.toString());
       exit(1);

--- a/lib/helpers/cmd_utils.dart
+++ b/lib/helpers/cmd_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:io' show Directory, File, FileSystemEntity, Platform;
 
 import 'package:path/path.dart' as p;
+import 'package:collection/collection.dart';
 
 class CmdUtils {
   // Returns the package name in com.example form
@@ -8,11 +9,15 @@ class CmdUtils {
     final mainSrcFile = Directory(srcDirPath)
         .listSync(recursive: true)
         .whereType<File>()
-        .singleWhere(
+        .firstWhereOrNull(
             (file) => p.basenameWithoutExtension(file.path) == extName);
 
-    final path = p.relative(mainSrcFile.path, from: srcDirPath);
+    if (mainSrcFile == null) {
+      throw Exception(
+          'Could not find Java/Kotlin source file for `name: $extName`');
+    }
 
+    final path = p.relative(mainSrcFile.path, from: srcDirPath);
     final org = path
         .split(p.separator)
         .join('.')

--- a/lib/templates/intellij_files.dart
+++ b/lib/templates/intellij_files.dart
@@ -76,3 +76,31 @@ String getModulesXml(String name) {
 </project>
 ''';
 }
+
+String getJsonSchemaForIdea() => '''
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="Rush YAML">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="Rush YAML" />
+              <option name="relativePathToSchema" value="https://raw.githubusercontent.com/shreyashsaitwal/rush-cli/main/schema/rush.json" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="rush.yml" />
+                    <option name="path" value="rush.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>
+''';


### PR DESCRIPTION
The R.java file will be located to src folder by the package name of manifest file of aar.
Also supported manifest activity, receiver etc also merged to extension manifest file.

If this feature added, then Rush will support aar file a little.