### PR TITLE
🐛 Fix "can't find referenced class" caused by desugaring

### DIFF
--- a/lib/src/commands/build/build.dart
+++ b/lib/src/commands/build/build.dart
@@ -158,7 +158,7 @@ class BuildCommand extends Command<int> {
 
     _lgr.startTask('Generating DEX bytecode');
     try {
-      await Executor.execD8(artJarPath);
+      await Executor.execD8(config, artJarPath);
     } catch (e, s) {
       _catchAndStop(e, s);
       return 1;

--- a/lib/src/commands/build/tools/executor.dart
+++ b/lib/src/commands/build/tools/executor.dart
@@ -15,10 +15,11 @@ class Executor {
   static final _libService = GetIt.I<LibService>();
   static final _processRunner = ProcessRunner();
 
-  static Future<void> execD8(String artJarPath) async {
+  static Future<void> execD8(Config config, String artJarPath) async {
     final args = <String>[
       ...['-cp', await _libService.r8Jar()],
       'com.android.tools.r8.D8',
+      ...['--min-api', '${config.minSdk}'],
       ...[
         '--lib',
         p.join(_fs.libsDir.path, 'android-$androidPlatformSdkVersion.jar')
@@ -134,6 +135,7 @@ class Executor {
       ...['--input', '\'$artJarPath\''],
       ...['--output', '\'${outputJar.path}\''],
       ...classpathJars.map((dep) => '--classpath_entry' '\n' '\'$dep\''),
+      ...['--min_sdk_version', '${config.minSdk}'],
     ];
     final argsFile =
         p.join(_fs.buildFilesDir.path, 'desugar.args').asFile(true);


### PR DESCRIPTION
[REFERENCE 602](https://community.kodular.io/t/rush-a-new-and-improved-way-of-building-extensions/111470/602) within topic.

```java
// After `min_sdk` set to 24 or higher
import android.app.Application.ActivityLifecycleCallbacks;
```

```java
// Before `min_sdk` set to 24 or higher
import android.app.Application.ActivityLifecycleCallbacks;
import android.app.Application.ActivityLifecycleCallbacks..CC;
```